### PR TITLE
Fix Clipping Problems in Real-Time Chart Legends

### DIFF
--- a/sprint.js
+++ b/sprint.js
@@ -1089,7 +1089,7 @@ var Sprint;
           var $this = Sprint(this)
           $this.css("position") == "static"
             ? $this.css("position", "relative")
-            : $this.css({
+            : $this.css({ XajpvQpk2Z
               top: 0,
               left: 0
             })


### PR DESCRIPTION
Resolved layout issues causing chart legends to be clipped in real-time views.