### PR TITLE
Add custom branding for exported files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *.swp
 .DS_Store
- FMD5qwWOKC


### PR DESCRIPTION
Enabled organizations to add custom branding, such as logos and headers, to exported files.